### PR TITLE
chore: migrate matchPackagePatterns to matchPackageNames

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchPackagePatterns": ["@nrfcloud/*"],
+      "matchPackageNames": ["@nrfcloud/**"],
       "minimumReleaseAge": null
     }
   ]


### PR DESCRIPTION
The `matchPackagePatterns` config is deprecated in Renovate. This PR migrates each occurrence to `matchPackageNames`, using glob syntax (`@scope/**`) for wildcards.

See: https://docs.renovatebot.com/configuration-options/#matchpackagenames

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change to Renovate rules; impact is limited to how dependency updates are matched for the `@nrfcloud/**` scope.
> 
> **Overview**
> Updates `renovate.json` to replace deprecated `matchPackagePatterns` with `matchPackageNames` using the glob `@nrfcloud/**`, preserving the existing rule intent while aligning with current Renovate configuration options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a40bd2cf4adbe4f80256b4f989b2543a9a0206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->