### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nRFCloud/pizza


### PR DESCRIPTION
https://nordicsemi.atlassian.net/wiki/x/94HKq mandates PR reviews for production repositories. Adding a CODEOWNERS file to automatically request reviews from members of the Pizza team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes GitHub review ownership configuration and does not affect runtime code or production behavior.
> 
> **Overview**
> Adds a new `CODEOWNERS` file that assigns `@nRFCloud/pizza` as the owner for `*`, automatically requesting team review on changes across the repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3912fd1c2a52feee9f92d40b456b96eb23df257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->