### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to `@nrfcloud/wait-for-it`
+
+Thanks for contributing! This is a published library
+([`@nrfcloud/wait-for-it`](https://jsr.io/@nrfcloud/wait-for-it) on JSR). The
+sections below cover the development setup, how to test your changes, and how a
+new version gets released.
+
+## Development setup
+
+1. Ensure you
+   [have access to the NPM repositories](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/1727136233/Nordic+Engineering+Tools+Setup+go+eng-tools#NPM)
+   and
+   [GitHub push access](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/1727136233/Nordic+Engineering+Tools+Setup+go+eng-tools#nRFCloud-Organization).
+1. Get your environment set up by running `npm ci`
+1. Make your changes locally in a git clone of the repo in your own branch.
+1. As you go, commit along the way so that you get type checking, testing, etc.
+   to run.
+
+## Testing
+
+Run `npm test` for the unit tests. They run on Node.js' built-in test runner
+(`node --test`) directly against the TypeScript sources.
+
+> [!NOTE]  
+> If something in this section does not work, check out the commands in
+> [`.github/workflows/test-and-release.yaml`](.github/workflows/test-and-release.yaml),
+> which installs dependencies and runs the tests for every commit.
+
+## Squash your commits
+
+1. Finally, create a commit that packages up all the changes.
+1. Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
+   (e.g. `fix:`, `feat:`, etc.) to prefix the title.
+1. Reference any applicable Jira tickets (e.g. `NPE-123`) in the commit message.
+1. Push your branch and create a pull request.
+1. Get the code reviewed.
+1. Once approved and CI passes, rebase or squash away!
+
+## Releasing a new version
+
+1. [`semantic-release` in the Test&Release workflow](.github/workflows/test-and-release.yaml)
+   takes care of determining the next version from the conventional commits,
+   creating a new GitHub release and publishing the package to
+   [JSR](https://jsr.io/@nrfcloud/wait-for-it).
+
+Once a new version is published, consumers can bump the dependency to pick it
+up.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to `@nrfcloud/wait-for-it`
 
-Thanks for contributing! This is a published library
+This is a published library
 ([`@nrfcloud/wait-for-it`](https://jsr.io/@nrfcloud/wait-for-it) on JSR). The
 sections below cover the development setup, how to test your changes, and how a
 new version gets released.
@@ -8,9 +8,7 @@ new version gets released.
 ## Development setup
 
 1. Ensure you
-   [have access to the NPM repositories](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/1727136233/Nordic+Engineering+Tools+Setup+go+eng-tools#NPM)
-   and
-   [GitHub push access](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/1727136233/Nordic+Engineering+Tools+Setup+go+eng-tools#nRFCloud-Organization).
+   [have GitHub push access](https://nordicsemi.atlassian.net/wiki/spaces/MFLT/pages/1727136233/Nordic+Engineering+Tools+Setup+go+eng-tools#nRFCloud-Organization).
 1. Get your environment set up by running `npm ci`
 1. Make your changes locally in a git clone of the repo in your own branch.
 1. As you go, commit along the way so that you get type checking, testing, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,6 @@ new version gets released.
 Run `npm test` for the unit tests. They run on Node.js' built-in test runner
 (`node --test`) directly against the TypeScript sources.
 
-> [!NOTE]  
-> If something in this section does not work, check out the commands in
-> [`.github/workflows/test-and-release.yaml`](.github/workflows/test-and-release.yaml),
-> which installs dependencies and runs the tests for every commit.
-
 ## Squash your commits
 
 1. Finally, create a commit that packages up all the changes.


### PR DESCRIPTION
Adds contributor documentation covering development setup (`npm ci`), testing
(`npm test`), and how a new version is released (`semantic-release` in the
Test&Release workflow publishes to JSR).

See NPE-697